### PR TITLE
bugfix: null data and asset images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Union Area Monorepo
+# Union Arena Monorepo
 
 ## Working locally
 
@@ -16,4 +16,14 @@ $ pnpm i
 
 ```bash
 $ pnpm run dev
+```
+
+## Scripts
+
+There are some scripts located in `scripts/`, which are useful programs that are not categorized or classified as `packages` or `apps` but can serve a utilitarian purpose through the cli.
+
+Scripts are intended to be run the following way:
+
+```bash
+$ npx tsx <some-script>.ts --args
 ```

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },
   "devDependencies": {
+    "@types/node": "^20.14.8",
     "dotenv": "^16.4.5",
     "prettier": "^3.2.5",
     "turbo": "^2.3.1",

--- a/packages/scrapper/src/index.ts
+++ b/packages/scrapper/src/index.ts
@@ -26,18 +26,18 @@ const main = async () => {
       },
     ]);
 
-    // Useful if script starts hanging
+    // Useful if script starts hanging.
     const resumeIndex = answers.resumeIndex ? Number(answers.resumeIndex) : 0;
 
     /**
-     * Set the directory to save the data to
+     * Set the directory to save the data to.
      * */
     await createDir(answers.path);
 
     const data = await scrape(answers.url);
 
     /**
-     * Perform a loop to save each card into a dir
+     * Perform a loop to save each card into a dir.
      * */
     let saved = 0;
     for (let i = resumeIndex; i < data.length; i++) {
@@ -58,65 +58,67 @@ const main = async () => {
 
 /**
  * Handles the saving of a card, returns the card name
- * when completed successfully
+ * when completed successfully.
  * */
 const saveCard = async (card: Card, dir: string): Promise<string> => {
   try {
     /**
      * Creates a directory: /foo/bar/
      * Where foo is the inquierer dir,
-     * bar is the name of the card
+     * bar is the name of the card.
      * */
     const CARD_FILE_NAME: string = "card.json";
     const cardDir = card.name.split(" ").join("-").toLowerCase();
 
-    // Create the dir for the card
+    // Create the dir for the card.
     const constructedDir = join(dir, cardDir);
     await createDir(constructedDir);
 
-    // Create the dir for the card assets
+    // Create the dir for the card assets.
     const assetsDir = join(constructedDir, "assets");
     await createDir(assetsDir);
 
     /**
-     * Handle the images
+     * Save the main card image.
      * */
     const imagePath = join(constructedDir, `card-image.webp`);
     await writeImage(card.image, imagePath);
 
+    /**
+     * Save the effectData images.
+     * */
     const parsedEffectData = domParser(card.effectData);
+    for (let i = 0; i < parsedEffectData.images.length; i++) {
+      const effectDataImage = parsedEffectData.images[i].src;
+      const constructedImageName = `effect-${i}.webp`;
+      const constructedImagePath = `${assetsDir}/${constructedImageName}`;
+      await writeImage(effectDataImage, constructedImagePath);
+    }
     const builtEffectDataText = buildParsedOrder(
       parsedEffectData.parserResultOrder,
       parsedEffectData.images,
       parsedEffectData.text,
     );
-    if (card.effectData) {
-      for (let i = 0; i < parsedEffectData.images.length; i++) {
-        const effectDataImage = parsedEffectData.images[i].src;
-        const constructedImageName = `effect-${i}.webp`;
-        const constructedImagePath = `${assetsDir}/${constructedImageName}`;
-        await writeImage(effectDataImage, constructedImagePath);
-      }
-    }
 
+    /**
+     * Save the triggerData images.
+     * */
     const parsedTriggerData = domParser(card.triggerData);
+    for (let i = 0; i < parsedTriggerData.images.length; i++) {
+      const triggerDataImage = parsedTriggerData.images[i].src;
+      const constructedImageName = `trigger-${i}.webp`;
+      const constructedImagePath = `${assetsDir}/${constructedImageName}`;
+      await writeImage(triggerDataImage, constructedImagePath);
+    }
     const builtTriggerDataText = buildParsedOrder(
       parsedTriggerData.parserResultOrder,
       parsedTriggerData.images,
       parsedTriggerData.text,
     );
-    if (card.triggerData) {
-      for (let i = 0; i < parsedTriggerData.images.length; i++) {
-        const triggerDataImage = parsedTriggerData.images[i].src;
-        const constructedImageName = `trigger-${i}.webp`;
-        const constructedImagePath = `${assetsDir}/${constructedImageName}`;
-        await writeImage(triggerDataImage, constructedImagePath);
-      }
-    }
 
     /**
      * Saves the card data to the directory:
-     * /foo/bar/card.json
+     * /foo/bar/card.json.
      * */
     const formattedCardData: FormattedCard = {
       cardNo: card.cardNo,
@@ -133,9 +135,18 @@ const saveCard = async (card: Card, dir: string): Promise<string> => {
       generatedEnergyData: card.generatedEnergyData
         ? Number(card.generatedEnergyData)
         : null,
-      effectData: card.effectData !== "" ? dashProp(builtEffectDataText) : null,
+      effectData:
+        card.effectData !== ""
+          ? dashProp(builtEffectDataText)
+            ? dashProp(builtEffectDataText)
+            : null
+          : null,
       triggerData:
-        card.triggerData !== "" ? dashProp(builtTriggerDataText) : null,
+        card.triggerData !== ""
+          ? dashProp(builtTriggerDataText)
+            ? dashProp(builtTriggerDataText)
+            : null
+          : null,
       getInfoData: card.getInfoData ? card.getInfoData : null,
     };
 

--- a/packages/scrapper/src/utils/parsers.ts
+++ b/packages/scrapper/src/utils/parsers.ts
@@ -16,7 +16,7 @@ export const domParser = (data: string): ParserResult => {
   let currentNode: ChildNode | null = document.body.firstChild;
 
   while (currentNode) {
-    if (currentNode.nodeType !== dom.window.Node.ELEMENT_NODE) {
+    if (currentNode.nodeType === dom.window.Node.TEXT_NODE) {
       const textContent = currentNode.textContent?.trim();
       if (textContent) {
         result.text.push(textContent);
@@ -26,8 +26,8 @@ export const domParser = (data: string): ParserResult => {
       const element = currentNode as Element;
       if (element.tagName === "IMG") {
         result.images.push({
-          src: element.getAttribute("src") || "",
-          alt: element.getAttribute("alt") || "",
+          src: element.getAttribute("src") as string,
+          alt: element.getAttribute("alt") as string,
         });
         result.parserResultOrder.push("img");
       }
@@ -50,7 +50,10 @@ export const domParser = (data: string): ParserResult => {
  * into a friendly standard format.
  * */
 export const dashProp = (data: string[]): string => {
-  return data.map((word) => word?.toLowerCase().replace(/\s+/g, "-")).join("%");
+  const str = data
+    .map((word) => word?.toLowerCase().replace(/\s+/g, "-"))
+    .join("%");
+  return str === "null" ? "" : str;
 };
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@types/node':
+        specifier: ^20.14.8
+        version: 20.17.6
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5

--- a/scripts/check-card-categories.ts
+++ b/scripts/check-card-categories.ts
@@ -1,0 +1,72 @@
+import fs from "fs/promises";
+import { join } from "path";
+import type { Card } from "../packages/scrapper/src/types/";
+
+/**
+ * This CLI tools checks a directory of cards,
+ * and logs the unique 'categoryData' field in the 'card.json'
+ * file.
+ *
+ * Only unique 'categoryData' strings will be logged and outputted as an
+ * array of string.
+ *
+ * USAGE:
+ * ```bash
+ * $ npx tsx check-card-categories.ts --dir='<path-to-cards-dir>'
+ * ```
+ * */
+
+const args = process.argv.slice(2);
+
+const findArg = (key: string): string | undefined => {
+  const arg = args.find((arg) => arg.startsWith(`${key}=`));
+  return arg ? arg.split("=")[1] : undefined;
+};
+
+const getDirectories = async (path: string): Promise<string[]> => {
+  const entries = await fs.readdir(path, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(path, entry.name));
+};
+
+const findFile = async (
+  dir: string,
+  target: string,
+): Promise<string | null> => {
+  const files = await fs.readdir(dir);
+  for (const file of files) {
+    if (file === target) {
+      return join(dir, file);
+    }
+  }
+  return null;
+};
+
+const parseFile = async (path: string): Promise<Card> => {
+  const content = await fs.readFile(path, "utf8");
+  return JSON.parse(content) as Card;
+};
+
+const dir = findArg("--dir");
+
+if (!dir) throw new Error("no directory specified.");
+
+const main = async () => {
+  const dirs = await getDirectories(dir);
+  const CARD_FILE_NAME = "card.json";
+  const categories: string[] = [];
+  for (let i = 0; i < dirs.length; i++) {
+    const file = await findFile(dirs[i], CARD_FILE_NAME);
+    if (!file)
+      throw new Error(
+        `file with name: ${CARD_FILE_NAME} not located in: ${dirs[i]}`,
+      );
+    const { categoryData } = await parseFile(file);
+    categories.push(categoryData);
+  }
+  const uniqueCategories = [...new Set(categories)];
+  console.log(uniqueCategories);
+};
+
+main();

--- a/scripts/check-card-categories.ts
+++ b/scripts/check-card-categories.ts
@@ -1,6 +1,6 @@
 import fs from "fs/promises";
 import { join } from "path";
-import type { Card } from "../packages/scrapper/src/types/";
+import type { FormattedCard } from "../packages/scrapper/src/types/";
 
 /**
  * This CLI tools checks a directory of cards,
@@ -43,9 +43,9 @@ const findFile = async (
   return null;
 };
 
-const parseFile = async (path: string): Promise<Card> => {
+const parseFile = async (path: string): Promise<FormattedCard> => {
   const content = await fs.readFile(path, "utf8");
-  return JSON.parse(content) as Card;
+  return JSON.parse(content) as FormattedCard;
 };
 
 const dir = findArg("--dir");


### PR DESCRIPTION
Updates the `scrapper` package to correctly parse 'null' data on effectData and triggerData, as well as correctly save the asset images

Adds script in new dir `scripts` to check unique card categories.